### PR TITLE
Correcion Metodo "eliminar_final"

### DIFF
--- a/08_parentesis/lista.hpp
+++ b/08_parentesis/lista.hpp
@@ -111,12 +111,20 @@ void Lista<T>::eliminar_final() {
         return;
     }
 
+    // Caso de lista que tiene un solo nodo
+    if (cabeza->siguiente == nullptr) {
+        delete cabeza;
+        cabeza = nullptr;
+        return;
+    }
+
     Nodo<T>* temp = cabeza;
-    while (temp->siguiente != nullptr) {
+    while (temp->siguiente->siguiente != nullptr) { // Se detiene en el penultimo nodo
         temp = temp->siguiente;
     }
+
+    delete temp->siguiente; // Eliminar el último nodo
     temp->siguiente = nullptr;
-    delete temp->siguiente;
 }
 
 template <typename T>
@@ -126,7 +134,7 @@ void Lista<T>::imprimir() {
     while (temp != nullptr) {
         std::cout << temp->dato << " -> ";
         temp = temp->siguiente;
-    }
+    }   
     std::cout << "NULL\n";
 }
 


### PR DESCRIPTION
Si el bucle se detenia en `temp->siguiente == nullptr` y luego se intentaba eliminar el `temp->siguiente`, se estaria queriendo eliminar un puntero nulo.
Por lo tanto, se tiene que parar en el penultimo nodo, y de ahi eliminar `temp->siguiente`, el cual ahi si seria el ultimo nodo el que se esta eliminando.
Ademas se agrega el caso en el cual la lista contenga un unico nodo.

Hago esta PR por las dudas que luego un compañero quisiera revisar esta parte de la clase.
Saludos!